### PR TITLE
Send BlockStart when evaluating a block

### DIFF
--- a/src/core/Evaluate.re
+++ b/src/core/Evaluate.re
@@ -40,10 +40,7 @@ type result =
       blockLoc: option(Loc.t),
       blockContent,
     }
-  | Directive{
-		blockLoc: option(Loc.t),
-		msg: string
-	};
+  | Directive(string);
 
 type evalResult =
   | EvalSuccess

--- a/src/core/Evaluate.re
+++ b/src/core/Evaluate.re
@@ -22,13 +22,16 @@ type warning = {
 
 [@deriving show]
 type blockContent =
+  | BlockStart
   | BlockSuccess{
       msg: string,
       warnings: list(warning),
+      stdout: string,
     }
   | BlockError{
       error,
       warnings: list(warning),
+      stdout: string,
     };
 
 [@deriving show]
@@ -36,9 +39,11 @@ type result =
   | Phrase{
       blockLoc: option(Loc.t),
       blockContent,
-      blockStdout: string,
     }
-  | Directive(string);
+  | Directive{
+		blockLoc: option(Loc.t),
+		msg: string
+	};
 
 type evalResult =
   | EvalSuccess

--- a/src/repl/Evaluate.re
+++ b/src/repl/Evaluate.re
@@ -126,14 +126,14 @@ let eval =
           switch (stdout, msg) {
           | ("", "") => ()
           | (msg, "")
-          | ("", msg) => send(Directive({blockLoc, msg}))
-          | (msg1, msg2) => send(Directive({blockLoc, msg: msg1 ++ "\n" ++ msg2}))
+          | ("", msg) => send(Directive(msg))
+          | (msg1, msg2) => send(Directive(msg1 ++ "\n" ++ msg2))
           };
           loop(tl);
         | (Parsetree.Ptop_dir(_, _), Error(exn)) =>
           let extractedWarnings = warnings^;
           let {errMsg, _} = Report.reportError(exn);
-          send(Directive({msg: errMsg, blockLoc}));
+          send(Directive(errMsg));
           /* Ignore directive errors */
           loop(tl);
         | (Parsetree.Ptop_def(_), Ok((true, ""))) => loop(tl)

--- a/src/repl/Evaluate.re
+++ b/src/repl/Evaluate.re
@@ -136,7 +136,6 @@ let eval =
           send(Directive(errMsg));
           /* Ignore directive errors */
           loop(tl);
-        | (Parsetree.Ptop_def(_), Ok((true, ""))) => loop(tl)
         | (Parsetree.Ptop_def(_), Ok((true, msg))) =>
           let extractedWarnings = warnings^;
           send(

--- a/src/test/repl/EvaluateTest.re
+++ b/src/test/repl/EvaluateTest.re
@@ -37,9 +37,6 @@ let success = (~warnings=[], ~stdout="", msg, block_start, block_end) =>
     blockContent: BlockSuccess({msg, warnings, stdout}),
   });
 
-let directive = (~msg, ~blockLoc) => 
-Directive({msg, blockLoc: Some(blockLoc)});
-
 let error =
     (
       ~warnings=[],
@@ -64,7 +61,7 @@ let error =
           errSub,
         },
         warnings,
-		stdout,
+        stdout,
       }),
   });
 };
@@ -296,7 +293,7 @@ describe("directives", ({test, _}) => {
     expect.mock(mockComplete).toBeCalledWith(EvalSuccess);
     /* Inspect each block calls */
     expect.mock(mock).toBeCalledTimes(2);
-    expect.mock(mock).toBeCalledWith(directive(~msg="let a: int;\n", ~blockLoc=makeLoc((1, 1), (1, 1))));
+    expect.mock(mock).toBeCalledWith(Directive("let a: int;\n"));
   });
 
   test("directive output to Toploop.execute_phrase buffer", ({expect}) => {
@@ -313,7 +310,7 @@ describe("directives", ({test, _}) => {
     expect.mock(mockComplete).toBeCalledTimes(1);
     expect.mock(mockComplete).toBeCalledWith(EvalSuccess);
     /* Inspect each block calls */
-    expect.mock(mock).toBeCalledWith(directive(~msg="Wrong type of argument for directive `show_val'.\n", ~blockLoc=makeLoc((1, 1), (1, 1))));
+    expect.mock(mock).toBeCalledWith(Directive("Wrong type of argument for directive `show_val'.\n"));
   });
 
   test("directive with error", ({expect}) => {
@@ -331,7 +328,7 @@ describe("directives", ({test, _}) => {
     expect.mock(mockComplete).toBeCalledWith(EvalSuccess);
     /* Inspect each block calls */
 
-    expect.mock(mock).toBeCalledWith(directive(~msg="Unbound value a", ~blockLoc=makeLoc((1,1), (1,1))));
+    expect.mock(mock).toBeCalledWith(Directive("Unbound value a"));
   });
 
   test(
@@ -350,7 +347,7 @@ describe("directives", ({test, _}) => {
     expect.mock(mockComplete).toBeCalledWith(EvalSuccess);
     /* Inspect each block calls */
     expect.mock(mock).toBeCalledTimes(3);
-    expect.mock(mock).toBeCalledWith(directive(~msg="Unbound value a", ~blockLoc=makeLoc((1,1), (1,1))));
+    expect.mock(mock).toBeCalledWith(Directive("Unbound value a"));
     let calls = Mock.getCalls(mock) |> List.rev;
     expect.equal(
       List.nth(calls, 1),

--- a/src/test/repl/EvaluateTest.re
+++ b/src/test/repl/EvaluateTest.re
@@ -272,7 +272,7 @@ describe("stdout", ({test, _}) =>
     /* Inspect each block calls */
     expect.mock(mock).toBeCalledTimes(2);
 	
-	let calls = Mock.getCalls(mock) |> List.rev;
+    let calls = Mock.getCalls(mock) |> List.rev;
     expect.equal(
       List.nth(calls, 1),
       success(~stdout="Hello world\n", "- : unit = ()", (0, 0), (0, 27)),

--- a/src/test/repl/EvaluateTest.re
+++ b/src/test/repl/EvaluateTest.re
@@ -34,9 +34,11 @@ let makeWarning = (~sub=[], ~number, ~msg, block_start, block_end) => {
 let success = (~warnings=[], ~stdout="", msg, block_start, block_end) =>
   Phrase({
     blockLoc: Some(makeLoc(block_start, block_end)),
-    blockContent: BlockSuccess({msg, warnings}),
-    blockStdout: stdout,
+    blockContent: BlockSuccess({msg, warnings, stdout}),
   });
+
+let directive = (~msg, ~blockLoc) => 
+Directive({msg, blockLoc: Some(blockLoc)});
 
 let error =
     (
@@ -62,8 +64,8 @@ let error =
           errSub,
         },
         warnings,
+		stdout,
       }),
-    blockStdout: stdout,
   });
 };
 
@@ -294,7 +296,7 @@ describe("directives", ({test, _}) => {
     expect.mock(mockComplete).toBeCalledWith(EvalSuccess);
     /* Inspect each block calls */
     expect.mock(mock).toBeCalledTimes(2);
-    expect.mock(mock).toBeCalledWith(Directive("let a: int;\n"));
+    expect.mock(mock).toBeCalledWith(directive(~msg="let a: int;\n", ~blockLoc=makeLoc((1, 1), (1, 1))));
   });
 
   test("directive output to Toploop.execute_phrase buffer", ({expect}) => {
@@ -311,9 +313,7 @@ describe("directives", ({test, _}) => {
     expect.mock(mockComplete).toBeCalledTimes(1);
     expect.mock(mockComplete).toBeCalledWith(EvalSuccess);
     /* Inspect each block calls */
-    expect.mock(mock).toBeCalledWith(
-      Directive("Wrong type of argument for directive `show_val'.\n"),
-    );
+    expect.mock(mock).toBeCalledWith(directive(~msg="Wrong type of argument for directive `show_val'.\n", ~blockLoc=makeLoc((1, 1), (1, 1))));
   });
 
   test("directive with error", ({expect}) => {
@@ -331,7 +331,7 @@ describe("directives", ({test, _}) => {
     expect.mock(mockComplete).toBeCalledWith(EvalSuccess);
     /* Inspect each block calls */
 
-    expect.mock(mock).toBeCalledWith(Directive("Unbound value a"));
+    expect.mock(mock).toBeCalledWith(directive(~msg="Unbound value a", ~blockLoc=makeLoc((1,1), (1,1))));
   });
 
   test(
@@ -350,7 +350,7 @@ describe("directives", ({test, _}) => {
     expect.mock(mockComplete).toBeCalledWith(EvalSuccess);
     /* Inspect each block calls */
     expect.mock(mock).toBeCalledTimes(3);
-    expect.mock(mock).toBeCalledWith(Directive("Unbound value a"));
+    expect.mock(mock).toBeCalledWith(directive(~msg="Unbound value a", ~blockLoc=makeLoc((1,1), (1,1))));
     let calls = Mock.getCalls(mock) |> List.rev;
     expect.equal(
       List.nth(calls, 1),

--- a/src/test/repl/EvaluateTest.re
+++ b/src/test/repl/EvaluateTest.re
@@ -82,19 +82,19 @@ describe("success test", ({test, _}) => {
     expect.mock(mockComplete).toBeCalledTimes(1);
     expect.mock(mockComplete).toBeCalledWith(EvalSuccess);
     /* Inspect each block calls */
-    expect.mock(mock).toBeCalledTimes(3);
+    expect.mock(mock).toBeCalledTimes(6);
     let calls = Mock.getCalls(mock) |> List.rev;
 
     expect.equal(
-      List.nth(calls, 0),
+      List.nth(calls, 1),
       success("let x: int = 1;", (0, 0), (0, 8)),
     );
     expect.equal(
-      List.nth(calls, 1),
+      List.nth(calls, 3),
       success("let y: int = 2;", (0, 11), (0, 19)),
     );
     expect.equal(
-      List.nth(calls, 2),
+      List.nth(calls, 5),
       success("let z: int = 3;", (0, 22), (0, 30)),
     );
   });
@@ -114,19 +114,19 @@ describe("success test", ({test, _}) => {
     expect.mock(mockComplete).toBeCalledTimes(1);
     expect.mock(mockComplete).toBeCalledWith(EvalSuccess);
     /* Inspect each block calls */
-    expect.mock(mock).toBeCalledTimes(3);
+    expect.mock(mock).toBeCalledTimes(6);
     let calls = Mock.getCalls(mock) |> List.rev;
 
     expect.equal(
-      List.nth(calls, 0),
+      List.nth(calls, 1),
       success("let x: int = 1;", (0, 0), (0, 8)),
     );
     expect.equal(
-      List.nth(calls, 1),
+      List.nth(calls, 3),
       success("let y: int = 2;", (1, 0), (1, 8)),
     );
     expect.equal(
-      List.nth(calls, 2),
+      List.nth(calls, 5),
       success("let z: int = 3;", (2, 0), (2, 8)),
     );
   });
@@ -145,11 +145,11 @@ describe("success test", ({test, _}) => {
     expect.mock(mockComplete).toBeCalledTimes(1);
     expect.mock(mockComplete).toBeCalledWith(EvalSuccess);
     /* Inspect each block calls */
-    expect.mock(mock).toBeCalledTimes(1);
+    expect.mock(mock).toBeCalledTimes(2);
     let calls = Mock.getCalls(mock) |> List.rev;
 
     expect.equal(
-      List.nth(calls, 0),
+      List.nth(calls, 1),
       success("let myFunc: unit => int = <fun>;", (0, 0), (2, 0)),
     );
   });
@@ -168,11 +168,11 @@ describe("success test", ({test, _}) => {
     expect.mock(mockComplete).toBeCalledTimes(1);
     expect.mock(mockComplete).toBeCalledWith(EvalSuccess);
     /* Inspect each block calls */
-    expect.mock(mock).toBeCalledTimes(2);
+    expect.mock(mock).toBeCalledTimes(4);
     let calls = Mock.getCalls(mock) |> List.rev;
 
     expect.equal(
-      List.nth(calls, 1),
+      List.nth(calls, 3),
       success(
         ~warnings=[
           makeWarning(
@@ -229,22 +229,22 @@ describe("error tests", ({test, _}) => {
     expect.mock(mockComplete).toBeCalledTimes(1);
     expect.mock(mockComplete).toBeCalledWith(EvalError);
     /* Inspect each block calls */
-    expect.mock(mock).toBeCalledTimes(3);
+    expect.mock(mock).toBeCalledTimes(6);
 
     let calls = Mock.getCalls(mock) |> List.rev;
 
     expect.equal(
-      List.nth(calls, 0),
+      List.nth(calls, 1),
       success("let a: int = 1;", (0, 0), (0, 8)),
     );
 
     expect.equal(
-      List.nth(calls, 1),
+      List.nth(calls, 3),
       success("let b: string = \"2\";", (0, 11), (0, 21)),
     );
 
     expect.equal(
-      List.nth(calls, 2),
+      List.nth(calls, 5),
       error(
         "This expression has type string but an expression was expected of type\n         int",
         Some(((0, 24), (0, 28))),
@@ -270,8 +270,11 @@ describe("stdout", ({test, _}) =>
     expect.mock(mockComplete).toBeCalledTimes(1);
     expect.mock(mockComplete).toBeCalledWith(EvalSuccess);
     /* Inspect each block calls */
-    expect.mock(mock).toBeCalledTimes(1);
-    expect.mock(mock).toBeCalledWith(
+    expect.mock(mock).toBeCalledTimes(2);
+	
+	let calls = Mock.getCalls(mock) |> List.rev;
+    expect.equal(
+      List.nth(calls, 1),
       success(~stdout="Hello world\n", "- : unit = ()", (0, 0), (0, 27)),
     );
   })
@@ -292,7 +295,7 @@ describe("directives", ({test, _}) => {
     expect.mock(mockComplete).toBeCalledTimes(1);
     expect.mock(mockComplete).toBeCalledWith(EvalSuccess);
     /* Inspect each block calls */
-    expect.mock(mock).toBeCalledTimes(2);
+    expect.mock(mock).toBeCalledTimes(4);
     expect.mock(mock).toBeCalledWith(Directive("let a: int;\n"));
   });
 
@@ -346,11 +349,11 @@ describe("directives", ({test, _}) => {
     expect.mock(mockComplete).toBeCalledTimes(1);
     expect.mock(mockComplete).toBeCalledWith(EvalSuccess);
     /* Inspect each block calls */
-    expect.mock(mock).toBeCalledTimes(3);
+    expect.mock(mock).toBeCalledTimes(6);
     expect.mock(mock).toBeCalledWith(Directive("Unbound value a"));
     let calls = Mock.getCalls(mock) |> List.rev;
     expect.equal(
-      List.nth(calls, 1),
+      List.nth(calls, 3),
       success("let x: int = 1;", (0, 13), (0, 21)),
     );
   });


### PR DESCRIPTION
Needed for:
![monaco-compilation-status](https://user-images.githubusercontent.com/13532591/57185458-e1857580-6e80-11e9-9c37-2d2a7cd20757.gif)

This adds a `BlockStart` evaluation result, which lets a consumer know the position of a code block that has begun evaluation.

TODO:
- [x] Remove the Directive location tagging
- [x] Get tests green again
